### PR TITLE
Add ability to initialize a repository while creating an idea

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -140,7 +140,7 @@ export const moveUserscriptIdea = async ({ org }: BotConfig, text: string) => {
 };
 
 /**
- * @summary adds a repository to organisation project
+ * @summary adds a repository to the organization project
  */
 export const addRepository = async ({ org }: BotConfig, text: string) => {
     const args = splitArgs(text);
@@ -151,20 +151,9 @@ export const addRepository = async ({ org }: BotConfig, text: string) => {
 
     const common = { private: p, name, description };
 
-    if (template) {
-        const res = await oktokit.rest.repos.createUsingTemplate({
-            ...common,
-            template_owner: org,
-            template_repo: template,
-            owner: org,
-        });
+    const res = await addRepositoryHandler(org, { ...common, template });
 
-        return sayCreatedRepo(res.data, true);
-    }
-
-    const res = await oktokit.rest.repos.createInOrg({ ...common, org });
-
-    return sayCreatedRepo(res.data);
+    return sayCreatedRepo(res, !!template);
 };
 
 /**

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -1,0 +1,42 @@
+import oktokit from "./userscripters.js";
+
+export interface AddRepositoryOptions {
+    description: string;
+    name: string;
+    private?: boolean;
+    template?: string;
+}
+
+/**
+ * @summary handler for an addRepository command
+ * @param org organization to create the repo for
+ * @param config command configuration
+ */
+export const addRepositoryHandler = async (
+    org: string,
+    config: AddRepositoryOptions
+) => {
+    const {
+        private: p = false,
+        template,
+        name,
+        description
+    } = config;
+
+    const common = { private: p, name, description };
+
+    if (template) {
+        const res = await oktokit.rest.repos.createUsingTemplate({
+            ...common,
+            template_owner: org,
+            template_repo: template,
+            owner: org,
+        });
+
+        return res.data;
+    }
+
+    const res = await oktokit.rest.repos.createInOrg({ ...common, org });
+
+    return res.data;
+};


### PR DESCRIPTION
This PR adds an ability to initialize a repository (reusing the `addRepository` command infrastructure) when creating an idea to reduce overhead when starting up new userscript projects.